### PR TITLE
Add pangu.js 添加 pangu.js 用来在中英文间添加空格

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.10-bookworm"
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/docs/_static/js/extra.js
+++ b/docs/_static/js/extra.js
@@ -1,0 +1,5 @@
+// We love spaces. See https://github.com/vinta/pangu.js/
+document.addEventListener('DOMContentLoaded', () => {
+    // listen to any DOM change and automatically perform spacing via MutationObserver()
+    pangu.autoSpacingPage();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,10 @@ theme:
     - c
     - cpp
 
+extra_javascript:
+  - 'https://cdnjs.loli.net/ajax/libs/pangu/4.0.7/pangu.min.js' # Pangu.js
+  - '_static/js/extra.js'
+
 plugins:
   - i18n:
       default_language: zh


### PR DESCRIPTION
[Pangu.js](https://github.com/vinta/pangu.js/) 能够为中英文之间自动添加空格，增加可读性。

添加前：
![Before](https://github.com/user-attachments/assets/432205d1-ee7f-4447-b58f-f6c79a280dc4)

添加后：
![After](https://github.com/user-attachments/assets/caed173d-1f1d-40a6-bc30-2b9dadfd11a6)


还提交了一个 DevContainer 配置文件，能够快速启动开发容器。