### PR TITLE
fix: no language switcher 修复了没有语言切换选项的问题

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,6 @@ default_language_only: true
 theme:
   name: material
   features:
-    - navigation.instant
     - navigation.tabs # 栏头加标签（一级导航）
     - navigation.tabs.sticky # 固定（浏览时不收起）标签
   highlightjs: true


### PR DESCRIPTION
上一个 PR 提交后，Github Action 构建的结果与本地不一致，经过排查日志发现可能是 Material 主题的 `navigation.instant` 选项与 `i18n` 插件冲突所致。[相关 Issue](https://github.com/ultrabug/mkdocs-static-i18n/issues/115)
本地测试发现去除相关选项后构建产物 `zh/index.html` 中包含语言切换按钮代码，而去除前不包含。