### PR TITLE
fix no language switch 修复了没有语言切换选项的问题

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,6 @@
 site_name: RevyOS Docs
 repo_name: revyos/docs
 repo_url: https://github.com/revyos/docs
-default_language: zh-CN
-default_language_only: true
 theme:
   name: material
   features:
@@ -22,6 +20,7 @@ extra_javascript:
 plugins:
   - i18n:
       default_language: zh
+      default_language_only: false
       languages:
         en:
           name: English

--- a/requirement.txt
+++ b/requirement.txt
@@ -3,6 +3,8 @@ charset-normalizer==3.2.0
 click==8.1.6
 colorama==0.4.6
 ghp-import==2.1.0
+gitdb==4.0.11
+GitPython==3.1.41
 idna==3.4
 importlib-metadata==6.8.0
 Jinja2==3.1.2
@@ -23,7 +25,9 @@ PyYAML==6.0.1
 pyyaml_env_tag==0.1
 regex==2023.8.8
 requests==2.31.0
+setuptools==69.0.3
 six==1.16.0
+smmap==5.0.1
 urllib3==2.0.4
 watchdog==3.0.0
 zipp==3.16.2


### PR DESCRIPTION
对上一个类似 PR 的修复。通过创建[最小可复现仓库](https://github.com/KamijoToma/revyos-docs-test)的方式，发现 

1.语言相关选项的位置与 `material-static-i18n` 说明不符 
2. `requirement.txt` 不同。

参考 [CI#4](https://github.com/KamijoToma/revyos-docs-test/actions/runs/12520075777) 和 [CI#5](https://github.com/KamijoToma/revyos-docs-test/actions/runs/12520133724) ,后者编译出的 HTML 文件现在带有语言切换选项。