### PR TITLE
fix logo size on mobile/wrong behavior when switch color theme

### DIFF
--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -25,7 +25,12 @@
 
 .logo {
   max-width: 25%;
-  max-height: 25%;
   width: auto;
   height: auto;
+}
+
+@media screen and (max-width: 996px) {
+  .logo {
+    max-width: 70vw;
+  }
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Layout from '@theme/Layout';
 import Translate, { translate } from '@docusaurus/Translate';
 import Link from '@docusaurus/Link';
@@ -7,9 +7,14 @@ import styles from './index.module.css';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import { useColorMode } from '@docusaurus/theme-common';
 
-const Logo = () => {
-  const isDark = useColorMode()['isDarkTheme'];
-  return (<img src={useBaseUrl(isDark ? 'img/RevyOS-logo-dark.svg' : 'img/RevyOS-logo.svg')} alt="logo of RevyOS" className={styles.logo} />)
+function Logo(){
+  const [dark, setDark] = useState(false);
+  const { colorMode } = useColorMode();
+  useEffect(() => {
+    setDark(colorMode === 'dark');
+  },[[]])
+
+  return (<img src={useBaseUrl(dark ? 'img/RevyOS-logo-dark.svg' : 'img/RevyOS-logo.svg')} alt="logo of RevyOS" className={styles.logo} />)
 }
 
 


### PR DESCRIPTION
Kagura: 修复首页logo在移动端过小；修复logo在切换主题后与主题颜色不对应的问题