### PR TITLE
Update image version of lpi4a and meles to 20250526

### DIFF
--- a/src/components/ImageLinks.tsx
+++ b/src/components/ImageLinks.tsx
@@ -10,14 +10,14 @@ interface ImageLink {
 export const imageLinks = [
   {
     device: "Lichee Pi 4A",
-    version: "20250420",
-    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250420/",
+    version: "20250526",
+    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/lpi4a/20250526/",
     sdCardSupport: true,
   },
   {
     device: "Milk-V Meles",
-    version: "20250420",
-    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/meles/20250420/",
+    version: "20250526",
+    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/meles/20250526/",
     sdCardSupport: true,
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Bump image versions to 20250526 for Lichee Pi 4A and Milk-V Meles.

Enhancements:
- Update Lichee Pi 4A image version and download link to 20250526
- Update Milk-V Meles image version and download link to 20250526