### PR TITLE
fix(imagelink): update milkv pioneer image version to 20250703

### DIFF
--- a/src/components/ImageLinks.tsx
+++ b/src/components/ImageLinks.tsx
@@ -22,8 +22,8 @@ export const imageLinks = [
   },
   {
     device: "Milk-V Pioneer",
-    version: "20241230",
-    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/sg2042/20241230/",
+    version: "20250703",
+    downloadLink: "https://mirror.iscas.ac.cn/revyos/extra/images/sg2042/20250703/",
     sdCardSupport: true,
   },
   {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Bump Milk-V Pioneer image version to 20250703 and adjust its download URL accordingly