### PR TITLE
fix build error

### DIFF
--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/alexnet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/alexnet.mdx
@@ -195,12 +195,12 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 <Tabs

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/efficientnet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/efficientnet.mdx
@@ -64,10 +64,6 @@ In this step, the `onnx` model is converted into a format compatible with the HH
 
 Navigate to the `classification/efficientnet` directory and execute the following commands:
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 29dad02 (校对修正和补充)
 
 ```shell-session
 $ hhb -D --model-file ./efficientnet_b0.onnx \
@@ -77,10 +73,6 @@ $ hhb -D --model-file ./efficientnet_b0.onnx \
     --input-shape "1 3 224 224" --quantization-scheme float16
 ```
 
-<<<<<<< HEAD
-=======
-
->>>>>>> 29dad02 (校对修正和补充)
 
 :::info[HHB Parameter Description]
 
@@ -206,7 +198,7 @@ For more details, refer to [Common Issues and Solutions](../../issues#npu-推理
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 ```shell-session

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/efficientnet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/efficientnet.mdx
@@ -193,7 +193,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv1.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv1.mdx
@@ -237,7 +237,7 @@ For more details, refer to [Common Issues and Solutions](../../issues#npu-推理
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 <Tabs
@@ -319,3 +319,4 @@ background
 tench, Tinca tinca
 ```
 </TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv1.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv1.mdx
@@ -232,7 +232,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv3.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv3.mdx
@@ -232,7 +232,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv4.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/inceptionv4.mdx
@@ -232,7 +232,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/mobilenetv1.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/mobilenetv1.mdx
@@ -194,7 +194,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/mobilenetv2.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/mobilenetv2.mdx
@@ -199,7 +199,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/resnet50.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/resnet50.mdx
@@ -189,7 +189,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/resnet50.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/resnet50.mdx
@@ -194,7 +194,7 @@ For more details, refer to [Common Issues and Solutions](../../issues#npu-推理
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 <Tabs
@@ -237,7 +237,7 @@ n02123159 tiger cat
 n02124075 Egyptian cat
 ```
 </TabItem>
-    <TabItem value="npu">
+<TabItem value="npu">
 ```shell-session
 $ ./resnet50_example
  ********** preprocess image **********
@@ -246,14 +246,8 @@ INFO: NNA clock:422733 [kHz]
 INFO: Heap :anonymous (0x2)
 INFO: Heap :dmabuf (0x2)
 INFO: Heap :unified (0x5)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 WARNING: Mapping to the on chip ram failed (128 > 0), continuing...
 FATAL: Importing 150528 bytes of CPU memory has failed (wrong memory alignment)
->>>>>>> 8e04e1f (新添npu部分英文补充)
-=======
->>>>>>> dced023 (修改resnet50模型和添加efficientnet模型cpu复现及中英文档移植)
 Run graph execution time: 17.87514ms, FPS=55.94
 
 === tensor info ===
@@ -281,9 +275,5 @@ n02123045 tabby, tabby cat
 n02123159 tiger cat
 n02124075 Egyptian cat
 ```
-    </TabItem>
-<<<<<<< HEAD
+</TabItem>
 </Tabs>
-=======
-</Tabs>
->>>>>>> dced023 (修改resnet50模型和添加efficientnet模型cpu复现及中英文档移植)

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/shufflenet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/shufflenet.mdx
@@ -27,15 +27,7 @@ The relevant code for this tutorial is located in the `classification/shufflenet
 
 ## Obtaining the Model
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-The model used in this tutorial is from the [ONNX Model Zoo](https://github.com/onnx/models/blob/main/validated/vision/classification/shufflenet/model/shufflenet-9.onnx). Download the ShuffleNet model with the following command:
-=======
 The model used in this tutorial is from the [ONNX Model Zoo](https://github.com/onnx/models/blob/main/validated/vision/classification/shufflenet/model/shufflenet-9.onnx). Download the Shufflenet model with the following command:
->>>>>>> 4dec8dd (新添shufflenet模型复现及中英文档移植)
-=======
-The model used in this tutorial is from the [ONNX Model Zoo](https://github.com/onnx/models/blob/main/validated/vision/classification/shufflenet/model/shufflenet-9.onnx). Download the ShuffleNet model with the following command:
->>>>>>> ba3441a (新添rtmpose 1 2 3模型复现及中英文档移植)
 
 ```shell-session
 $ curl -LO https://raw.githubusercontent.com/onnx/models/main/validated/vision/classification/shufflenet/model/shufflenet-9.onnx
@@ -191,7 +183,7 @@ For more details, refer to [Common Issues and Solutions](../../issues#npu-推理
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 ```shell-session

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/shufflenet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/shufflenet.mdx
@@ -178,7 +178,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/squeezenet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/squeezenet.mdx
@@ -193,7 +193,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/squeezenet.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/squeezenet.mdx
@@ -198,7 +198,7 @@ For more details, refer to [Common Issues and Solutions](../../issues#npu-推理
 
 ### Sample output:
 
-In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`. 
+In this tutorial, the input is a picture of a Persian cat. The expected result for ResNet50 is that the largest value is at index 283, corresponding to `Persian cat`.
 ![Persian cat](/img/image-for-flash/persian_cat.png)
 
 <Tabs
@@ -277,3 +277,4 @@ n01440764 tench, Tinca tinca
 n01443537 goldfish, Carassius auratus
 ```
 </TabItem>
+</Tabs>

--- a/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/vgg16.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/npu/lpi4a/image-classification/vgg16.mdx
@@ -195,7 +195,7 @@ It is recommended to configure `udev` rules for automatic permission setting. Co
 :::info[About Long NPU Inference Time]
 In theory, the program should run quickly. However, the first run may take over 5 minutes due to JIT compilation when loading the model on the NPU. Due to HHB runtime design, JIT compilation occurs on every run, resulting in long execution times.
 
-For more details, refer to [Common Issues and Solutions](../../issues#npu-推理运行时间过长).
+For more details, refer to [Common Issues and Solutions](../../issues#excessive-npu-inference-time).
 :::
 
 ### Sample output:


### PR DESCRIPTION
This PR only make minimum changes to achieve a successful build. No content has beed modified. So the NPU theme is still missing some content/contains misleading content.

Signed-off-by: KamijoToma <admin@misakacloud.net>

## Summary by Sourcery

Clean up MDX documentation errors and fix build failures in NPU image-classification tutorials

Documentation:
- Remove leftover Git merge conflict markers from NPU tutorial MDX files to restore valid markup
- Correct unmatched TabItem/</Tabs> tags and add missing newlines in documentation to ensure proper parsing
- Update "Common Issues and Solutions" anchor links to use consistent English fragment identifiers (#excessive-npu-inference-time)