### PR TITLE
docs: 将 `/dev/sda` 替换为 `/dev/sdX`，以防止误操作

### DIFF
--- a/docs/Installation/licheepi4a.mdx
+++ b/docs/Installation/licheepi4a.mdx
@@ -240,7 +240,7 @@ SD 卡的设备名可能是 /dev/sda 或 /dev/mmcblk0，在演示环境中，在
 在写入镜像前，需要卸载 SD 卡的挂载分区，如果有多个分区请逐一卸载：
 
 ```bash
-sudo umount /dev/sda1
+sudo umount /dev/sdX1
 ```
 
 如果没有分区被挂载，umount 命令会显示`not mounted`，这时无需进一步操作。
@@ -252,7 +252,7 @@ sudo umount /dev/sda1
 在执行完上述步骤后即可进行刷写，在刷写前请保证您在 `of=` 设置了正确的设备，在演示环境中，sd卡识别为sda，`of=`后请根据自身设备分区进行填写。
 
 ```bash
-sudo dd if=./sdcard-lpi4a-20250110_151339.img of=/dev/sda bs=4M status=progress
+sudo dd if=./sdcard-lpi4a-20250110_151339.img of=/dev/sdX bs=4M status=progress
 ```
 
 ![dd](/img/image-for-flash/dd.png)

--- a/docs/Installation/milkv-meles.mdx
+++ b/docs/Installation/milkv-meles.mdx
@@ -319,7 +319,7 @@ SD 卡的设备名可能是 /dev/sda 或 /dev/mmcblk0，在演示环境中，在
 在写入镜像前，需要卸载 SD 卡的挂载分区，如果有多个分区请逐一卸载：
 
 ```bash
-sudo umount /dev/sda1
+sudo umount /dev/sdX1
 ```
 
 如果没有分区被挂载，umount 命令会显示`not mounted`，这时无需进一步操作。
@@ -331,7 +331,7 @@ sudo umount /dev/sda1
 在执行完上述步骤后即可进行刷写，在刷写前请保证您在 `of=` 设置了正确的设备，在演示环境中，sd卡识别为sda，`of=`后请根据自身设备分区进行填写。
 
 ```bash
-sudo dd if=./sdcard-meles-20250323_154525.img of=/dev/sda bs=4M status=progress
+sudo dd if=./sdcard-meles-20250323_154525.img of=/dev/sdX bs=4M status=progress
 ```
 
 ![dd-meles](/img/image-for-flash/dd-meles.png)

--- a/docs/Installation/milkv-pioneer.mdx
+++ b/docs/Installation/milkv-pioneer.mdx
@@ -63,10 +63,10 @@ RevyOS 镜像刷写遵循固件文件 + 系统文件的方式，因此会用到�
 在存放 `firmware_single_sg2042-v6.6-lts-v0p7.img` 文件的目录下时，使用 dd 命令将文件刷写到 SD 卡中
 
 ```shell
-sudo dd if=firmware_single_sg2042-v6.6-lts-v0p7.img of=/dev/sda bs=4M status=progress
+sudo dd if=firmware_single_sg2042-v6.6-lts-v0p7.img of=/dev/sdX bs=4M status=progress
 ```
 
-`of=/dev/sda` 此项请根据设备路径进行更改
+`of=/dev/sdX` 此项请根据设备路径进行更改
 
 刷写完成后请使用`sync`命令，确保数据写入到 SD 卡中。
 

--- a/i18n/en/docusaurus-plugin-content-docs/current/Installation/licheepi4a.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Installation/licheepi4a.mdx
@@ -178,7 +178,7 @@ The device name for the SD card might be `/dev/sda` or `/dev/mmcblk0`. In the de
 Before writing the image, unmount any mounted partitions of the SD card. If there are multiple partitions, unmount each one:
 
 ```bash
-sudo umount /dev/sda1
+sudo umount /dev/sdX1
 ```
 
 If no partitions are mounted, the `umount` command will display `not mounted`, and no further action is needed.
@@ -190,7 +190,7 @@ After unmounting the partitions, it is recommended to run the `sudo sync` comman
 After completing the above steps, you can proceed with writing the image. Before writing, ensure that the correct device is set in the `of=` parameter. In the demonstration environment, the SD card is recognized as `sda`. Replace `of=` with your device's partition accordingly.
 
 ```bash
-sudo dd if=./sdcard-lpi4a-20250110_151339.img of=/dev/sda bs=4M status=progress
+sudo dd if=./sdcard-lpi4a-20250110_151339.img of=/dev/sdX bs=4M status=progress
 ```
 
 ![dd](/img/image-for-flash/dd.png)

--- a/i18n/en/docusaurus-plugin-content-docs/current/Installation/milkv-meles.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Installation/milkv-meles.mdx
@@ -313,7 +313,7 @@ The device name of the SD card may be /dev/sda or /dev/mmcblk0. In the demonstra
 Before writing the image, you need to unmount the mounted partition of the SD card. If there are multiple partitions, please unmount them one by one:
 
 ```bash
-sudo umount /dev/sda1
+sudo umount /dev/sdX1
 ```
 
 If no partition is mounted, the umount command will display `not mounted`, then no further action is required.
@@ -325,7 +325,7 @@ After unmounting the partition, it is recommended to run the `sudo sync` command
 After performing the above steps, you can start flashing. Before flashing, please ensure that you have set the correct device in `of=`. In the demonstration environment, the sd card is identified as sda. Please fill in the partition according to your own device after `of=`.
 
 ```bash
-sudo dd if=./sdcard-meles-20250323_154525.img of=/dev/sda bs=4M status=progress
+sudo dd if=./sdcard-meles-20250323_154525.img of=/dev/sdX bs=4M status=progress
 ```
 
 ![dd-meles](/img/image-for-flash/dd-meles.png)

--- a/i18n/en/docusaurus-plugin-content-docs/current/Installation/milkv-pioneer.mdx
+++ b/i18n/en/docusaurus-plugin-content-docs/current/Installation/milkv-pioneer.mdx
@@ -64,10 +64,10 @@ Insert the SD card into a reader connected to your computer, then verify the dev
 Navigate to the directory with `firmware_single_sg2042-v6.6-lts-v0p7.img` and flash it with the following command:
 
 ```shell
-sudo dd if=firmware_single_sg2042-v6.6-lts-v0p7.img of=/dev/sda bs=4M status=progress
+sudo dd if=firmware_single_sg2042-v6.6-lts-v0p7.img of=/dev/sdX bs=4M status=progress
 ```
 
-Replace `of=/dev/sda` with your specific device path if different.
+Replace `of=/dev/sdX` with your specific device path if different.
 
 After flashing, use `sync` to ensure data is fully written to the SD card.
 


### PR DESCRIPTION
## Summary by Sourcery

Replace hardcoded /dev/sda references in SD card flashing instructions with the generic placeholder /dev/sdX across multiple installation guides to prevent device misidentification.

Documentation:
- Update Chinese and English installation docs for licheepi4a to use /dev/sdX1 and /dev/sdX in unmount and dd commands
- Update Chinese and English installation docs for milkv-meles to use /dev/sdX1 and /dev/sdX in unmount and dd commands
- Update Chinese and English installation docs for milkv-pioneer to use /dev/sdX in dd commands and related notes