### PR TITLE
docs(desktop): update install command for RevyOS

### DIFF
--- a/docs/desktop/install.md
+++ b/docs/desktop/install.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 在RevyOS中安装包只需要在 terminal 中输入
 
 ```
-apt install + 包名
+sudo apt install + 包名
 ```
 即可安装
 


### PR DESCRIPTION
- Update the package install command in RevyOS instructions
- Change from 'apt install' to 'sudo apt install' for proper permissions

更改了`command`一下,以符合上下文

## Summary by Sourcery

Documentation:
- Change package install instruction to use 'sudo apt install' for proper permissions